### PR TITLE
Recompute Document Frequencies with Caching

### DIFF
--- a/src/main/java/hk/ust/comp4321/api/Document.java
+++ b/src/main/java/hk/ust/comp4321/api/Document.java
@@ -118,6 +118,10 @@ public final class Document {
      * @param jsoupDoc The webpage in Jsoup document form
      */
     public void retrieveFromWeb(org.jsoup.nodes.Document jsoupDoc) {
+
+        // Obtain a "cleaner" Jsoup document for body word extractions
+        org.jsoup.nodes.Document cleanJsoupDoc = Jsoup.parse(jsoupDoc.html().replaceAll("<br>|</br>", "\n"));
+
         // Load text processor
         TextProcessor textProcessor = TextProcessor.getInstance();
 
@@ -153,12 +157,16 @@ public final class Document {
             }
         }
 
-        // Extract body sections
-        Elements body = jsoupDoc.select("body");
+        // Extract body sections from the CLEANED version of the Jsoup document
+        Elements body = cleanJsoupDoc.select("body");
 
         // Note: A site can be empty
         if (!body.isEmpty()) {
-            List<String> bodySections = body.get(0).textNodes().stream().map(TextNode::text).toList();
+            List<String> bodySections = Arrays.stream(body.html().split("\n"))
+                                            .map(Jsoup::parse)
+                                            .map(Element::text)
+                                            .toList();
+
             // Paragraph level
             for (int i = 0; i < bodySections.size(); ++i) {
                 List<String> bodySentences = textProcessor.toSentence(bodySections.get(i));
@@ -190,7 +198,7 @@ public final class Document {
             try {
                 this.children.add(URI.create(link.attr("abs:href")).toURL());
             } catch (IllegalArgumentException | MalformedURLException ex) {
-//                System.out.println("Error occurred when crawling this page: " + link.attr("abs:href") + " and hence skipped");
+                System.out.println("Error occurred when crawling this page: " + link.attr("abs:href") + " and hence skipped");
             }
         }
 

--- a/src/main/java/hk/ust/comp4321/api/Document.java
+++ b/src/main/java/hk/ust/comp4321/api/Document.java
@@ -6,6 +6,7 @@ import hk.ust.comp4321.nlp.*;
 import hk.ust.comp4321.se.SearchVector;
 import hk.ust.comp4321.util.StopWord;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 import org.jsoup.nodes.Element;
 
@@ -36,6 +37,8 @@ public final class Document {
     private final List<URL> children = new ArrayList<>();
     private boolean isLoaded = false;
     private String title = "";
+    private SearchVector titleVector;
+    private SearchVector bodyVector;
 
     /**
      * Creates a new Document with the specified URL.
@@ -155,7 +158,7 @@ public final class Document {
 
         // Note: A site can be empty
         if (!body.isEmpty()) {
-            List<String> bodySections = body.get(0).children().stream().map(Element::text).toList();
+            List<String> bodySections = body.get(0).textNodes().stream().map(TextNode::text).toList();
             // Paragraph level
             for (int i = 0; i < bodySections.size(); ++i) {
                 List<String> bodySentences = textProcessor.toSentence(bodySections.get(i));
@@ -214,87 +217,7 @@ public final class Document {
             return;
         }
 
-        // Request execution successful. Execute the request as a GET and parse the result
-        org.jsoup.nodes.Document doc = docConnection.get();
-
-        // Load text processor
-        TextProcessor textProcessor = TextProcessor.getInstance();
-
-        // Extract title sections
-        // Note: There must be exactly one title per HTMl file (i.e., one "paragraph" only)
-        title = doc.select("title").text();
-        List<String> titleSentences = textProcessor.toSentence(title);
-        // Sentence level
-        for (int j = 0; j < titleSentences.size(); ++j) {
-            /*
-            For every sentence:
-            1. Tokenize the sentence
-            2. Filter out tokens that are all symbols
-            3. Turn all the tokens into lowercase
-             */
-            List<String> rawTitleWords = textProcessor.toTokens(titleSentences.get(j))
-                    .stream()
-                    .filter(text -> !TextProcessor.isAllSymbols(text))
-                    .map(String::toLowerCase).toList();
-            // Word level
-            for (int k = 0; k < rawTitleWords.size(); ++k) {
-                String rawWord = rawTitleWords.get(k);
-                // Put the stem to the map if it is not a stop word
-                if (!StopWord.isStopWord(rawWord)) {
-                    String stemmedWord = NltkPorter.stem(rawWord);
-                    // Store empty string is the stemmed word is identical to the raw word
-                    if (stemmedWord.equals(rawWord)) {
-                        this.titleFrequencies.put(new WordInfo(this.id, 0, j, k, ""), stemmedWord);
-                    } else {
-                        this.titleFrequencies.put(new WordInfo(this.id, 0, j, k, rawWord), stemmedWord);
-                    }
-                }
-            }
-        }
-
-        // Extract body sections
-        Elements body = doc.select("body");
-
-        // Note: A site can be empty
-        if (!body.isEmpty()) {
-            List<String> bodySections = body.get(0).children().stream().map(Element::text).toList();
-            // Paragraph level
-            for (int i = 0; i < bodySections.size(); ++i) {
-                List<String> bodySentences = textProcessor.toSentence(bodySections.get(i));
-                // Sentence level
-                for (int j = 0; j < bodySentences.size(); ++j) {
-                    List<String> rawBodyWords = textProcessor.toTokens(bodySentences.get(j))
-                            .stream()
-                            .filter(text -> !TextProcessor.isAllSymbols(text))
-                            .map(String::toLowerCase).toList();
-                    // Word level
-                    for (int k = 0; k < rawBodyWords.size(); ++k) {
-                        String rawWord = rawBodyWords.get(k);
-                        if (!StopWord.isStopWord(rawWord)) {
-                            String stemmedWord = NltkPorter.stem(rawWord);
-                            if (stemmedWord.equals(rawWord)) {
-                                this.bodyFrequencies.put(new WordInfo(this.id, i, j, k, ""), stemmedWord);
-                            } else {
-                                this.bodyFrequencies.put(new WordInfo(this.id, i, j, k, rawWord), stemmedWord);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Extract links
-        Elements links = doc.select("a[href]");
-        for (Element link : links) {
-            try {
-                this.children.add(URI.create(link.attr("abs:href")).toURL());
-            } catch (IllegalArgumentException | MalformedURLException ex) {
-//                System.out.println("Error occurred when crawling this page: " + link.attr("abs:href") + " and hence skipped");
-            }
-        }
-
-        // Document is completely loaded
-        isLoaded = true;
+        retrieveFromWeb(docConnection.get());
     }
 
     /**
@@ -412,24 +335,30 @@ public final class Document {
     }
 
     /**
-     * Converts the title s of this document into a search query.
-     * @param conn The database connection to look up this document in
+     * Converts the titles of this document into a search query.
+     * @param documents The list of all documents
      * @return The search vector corresponding to the titles in this document
      */
-    public SearchVector asTitleVector(DatabaseConnection conn) {
-        return termWeights(titleFrequencies, conn.titleOperator());
+    public SearchVector asTitleVector(List<Document> documents) {
+        if (titleVector == null) {
+            titleVector = termWeights(titleFrequencies, documents, d -> d.titleFrequencies);
+        }
+        return titleVector;
     }
 
     /**
      * Converts the body of this document into a search query.
-     * @param conn The database connection to look up this document in
+     * @param documents The list of all documents
      * @return The search vector corresponding to the body in this document
      */
-    public SearchVector asBodyVector(DatabaseConnection conn) {
-        return termWeights(bodyFrequencies, conn.bodyOperator());
+    public SearchVector asBodyVector(List<Document> documents) {
+        if (bodyVector == null) {
+            bodyVector = termWeights(bodyFrequencies, documents, d -> d.bodyFrequencies);
+        }
+        return bodyVector;
     }
 
-    private SearchVector termWeights(Map<WordInfo, String> info, TableOperation op) {
+    private SearchVector termWeights(Map<WordInfo, String> info, List<Document> docs, Function<Document, Map<WordInfo, String>> converter) {
         Map<String, Long> values = info.values().stream()
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         long maxTerm = values.values().stream().max(Long::compare).orElse(0L);
@@ -439,7 +368,8 @@ public final class Document {
         List<Map.Entry<String, Long>> l = values.entrySet().stream().toList();
         return new SearchVector(l.stream().map(Map.Entry::getKey).toList(),
                 l.stream().map(e -> e.getValue() * (Math.log((double) DatabaseConnection.getDocSize() /
-                        op.docFreq(e.getKey())) / Math.log(2)) / maxTerm).toList());
+                        docs.parallelStream().map(converter)
+                                .filter(m -> m.containsValue(e.getKey())).count()) / Math.log(2)) / maxTerm).toList());
     }
 
     @Override

--- a/src/main/java/hk/ust/comp4321/db/TableOperation.java
+++ b/src/main/java/hk/ust/comp4321/db/TableOperation.java
@@ -1,5 +1,6 @@
 package hk.ust.comp4321.db;
 
+import hk.ust.comp4321.api.Document;
 import hk.ust.comp4321.api.WordInfo;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
@@ -233,9 +234,8 @@ public abstract class TableOperation {
      * @return The list of all unique document IDs matching this stem
      */
     public List<Integer> getDocIdsWithStem(int stemId) {
-        return create.select(DSL.field(DSL.name("docId"))).from(DSL.table(DSL.name("ForwardIndex"))).where(
-                DSL.condition(DSL.field(DSL.name("wordId")).eq(stemId))
-                        .and(DSL.field(DSL.name("typePrefix")).eq(getPrefix())))
+        return create.select(DSL.field(DSL.name("docId")))
+                .from(DSL.table(DSL.name(getPrefix(stemId))))
                 .fetch()
                 .stream()
                 .map(r -> r.get(0, Integer.class))

--- a/src/main/java/hk/ust/comp4321/se/SearchEngine.java
+++ b/src/main/java/hk/ust/comp4321/se/SearchEngine.java
@@ -29,8 +29,8 @@ public class SearchEngine {
      */
     public List<Tuple<Document, Double>> search(SearchVector query) {
         return docs.stream()
-                .map(d -> new Tuple<>(d, d.asTitleVector(conn).cosineSim(query) * TITLE_BOOST_FACTOR +
-                        d.asBodyVector(conn).cosineSim(query)))
+                .map(d -> new Tuple<>(d, d.asTitleVector(docs).cosineSim(query) * TITLE_BOOST_FACTOR +
+                        d.asBodyVector(docs).cosineSim(query)))
                 .filter(d -> d.right() != 0.0)
                 .sorted(Comparator.<Tuple<Document, Double>, Double>comparing(Tuple::right).reversed())
                 .filter(d -> query.getRequiredTerms().stream()

--- a/src/main/java/hk/ust/comp4321/se/SearchVector.java
+++ b/src/main/java/hk/ust/comp4321/se/SearchVector.java
@@ -1,6 +1,7 @@
 package hk.ust.comp4321.se;
 
 import hk.ust.comp4321.nlp.NltkPorter;
+import hk.ust.comp4321.util.StopWord;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -36,6 +37,7 @@ public class SearchVector {
      * @param query The raw query string; May contain quotes
      */
     public SearchVector(String query) {
+        query = StopWord.stripStopwords(query);
         String slice = query;
         List<String> quotes = new ArrayList<>();
         int i;
@@ -84,6 +86,7 @@ public class SearchVector {
 
     @Override
     public String toString() {
-        return vector.entrySet().stream().map(e -> e.getKey() + " " + e.getValue()).collect(Collectors.joining(", "));
+        return "[" + vector.entrySet().stream()
+                .map(e -> e.getKey() + " " + e.getValue()).collect(Collectors.joining(", ")) + ", " + requiredTerms + "]";
     }
 }

--- a/src/main/java/hk/ust/comp4321/server/WebServer.java
+++ b/src/main/java/hk/ust/comp4321/server/WebServer.java
@@ -427,7 +427,7 @@ public class WebServer {
                         .collect(Collectors.groupingBy(s -> s, Collectors.counting()));
         String keyWords = frequencies.entrySet().stream().sorted(
                                     Map.Entry.<String, Long>comparingByValue().reversed())
-                                    .limit(10).map(e -> NltkPorter.stem(e.getKey())  + " " + e.getValue()).limit(5).collect(Collectors.joining("; "));
+                                    .limit(5).map(e -> NltkPorter.stem(e.getKey())  + " " + e.getValue()).collect(Collectors.joining("; "));
         String parentLinks = conn.parents(doc.id()).stream()
                                                     .map(x -> x.url().toString())
                                                     .map(x -> "<div class=\"searchResultPageLink\"><a href=\"%s\">%s</a></div>".formatted(x,x))

--- a/src/main/java/hk/ust/comp4321/server/WebServer.java
+++ b/src/main/java/hk/ust/comp4321/server/WebServer.java
@@ -33,7 +33,7 @@ public class WebServer {
         }
     }
 
-    private static String currentPage = getHomePage();
+    private static String currentPage = getHomepage();
     private static AtomicBoolean loaded = new AtomicBoolean(false);
 
     public static void main(String[] args) throws IOException, SQLException {
@@ -55,13 +55,13 @@ public class WebServer {
         Javalin app = Javalin.create()
                 .get("/", ctx -> {
                     if (loaded.get()) {
-                        ctx.html(getHomePage());
+                        ctx.html(getHomepage());
                     } else {
                         ctx.html("Our web server is pre-loading!");
                     }
                 })
                 .post("/home", ctx -> {
-                    currentPage = getHomePage();
+                    currentPage = getHomepage();
                     ctx.html(currentPage);
                 })
                 .post("/homeSearch", ctx -> {
@@ -69,7 +69,7 @@ public class WebServer {
                     String query = ctx.formParam("queryText");
 
                     if (query == null || query.trim().isEmpty()) {
-                        ctx.html(getHomePage());
+                        ctx.html(getHomepage());
                         return;
                     }
 
@@ -95,6 +95,9 @@ public class WebServer {
                     long end = System.currentTimeMillis();
                     currentPage = getSearchPage(query, search.size(), (double)(end - start) / 1000, search);
                     ctx.html(currentPage);
+                })
+                .error(404, ctx -> {
+                    ctx.html(getErrorPage());
                 });
         app.get("/shutdown", ctx -> {
             ctx.html("Shutting down...");
@@ -113,24 +116,25 @@ public class WebServer {
         loaded.set(true);
     }
 
-    private static String getErrorPage(String query) {
+    private static String getErrorPage() {
         return """
                 <!DOCTYPE html>
                 <html>
-                %s
+                <head>
+                    <title>Error 404 - COMP 4321 Group 42 Search Engine</title>
+                </head>
                 %s
                 <body>
                 %s
-                %s
-                <div style="padding: 10px;">The term "%s" does not exist.</div>
+                <div style="padding: 10px;">Error! Page not found.</div>
                 </body>
-                """.formatted(getSearchpageTitle(query), getSearchpageStyle(), getSearchpageHeader(), getSearchResultTitle(query), query);
+                """.formatted(getSearchpageStyle(), getSearchpageHeader());
     }
 
     private static String getHomepageTitle() {
         return """
                 <head>
-                    <title>COMP4321 Group 42 Search Engine</title>
+                    <title>COMP 4321 Group 42 Search Engine</title>
                 </head>
                """;
     }
@@ -210,14 +214,14 @@ public class WebServer {
                """;
     }
 
-    private static String getHomePage() {
+    private static String getHomepage() {
         return """
                 <!DOCTYPE html>
                 <html>
                 %s
                 %s
                 <body>
-                <h1 class="title">Search Engine</h1>
+                <h1 class="title">COMP 4321 Search Engine</h1>
                 <form id="homeSearchForm", action="/homeSearch" method="POST">
                     <div class="input-container">
                         <label for="queryText"></label>
@@ -234,7 +238,7 @@ public class WebServer {
     private static String getSearchpageTitle(String query) {
         return """
                 <head>
-                    <title> %s - Group 42 Search Engine</title>
+                    <title> %s - COMP 4321 Group 42 Search Engine</title>
                 </head>
                """.formatted(query);
     }
@@ -363,6 +367,13 @@ public class WebServer {
                     font-weight: normal;
                     text-align: left;
                 }
+                .searchResultPageTitle,
+                .searchResultPageLink,
+                .searchResultPageInfo,
+                .searchResultPageWordFreq,
+                .searchResultItemText {
+                    padding-left: 10px;
+                }
                 </style>
               """;
     }
@@ -394,7 +405,7 @@ public class WebServer {
 
     private static String getSearchResultTitle(String query) {
         return """
-               <div class="searchResultTitle">Search results for "%s"</div>
+               <div class="searchResultTitle">Search results for <span style="font-style:italic">%s</span></div>
                """.formatted(query);
     }
 

--- a/src/main/java/hk/ust/comp4321/server/WebServer.java
+++ b/src/main/java/hk/ust/comp4321/server/WebServer.java
@@ -2,6 +2,7 @@ package hk.ust.comp4321.server;
 
 import hk.ust.comp4321.api.Document;
 import hk.ust.comp4321.db.DatabaseConnection;
+import hk.ust.comp4321.nlp.NltkPorter;
 import hk.ust.comp4321.se.SearchEngine;
 import hk.ust.comp4321.se.SearchVector;
 import hk.ust.comp4321.util.DocumentLoadTask;
@@ -426,7 +427,7 @@ public class WebServer {
                         .collect(Collectors.groupingBy(s -> s, Collectors.counting()));
         String keyWords = frequencies.entrySet().stream().sorted(
                                     Map.Entry.<String, Long>comparingByValue().reversed())
-                                    .limit(10).map(e -> e.getKey() + " " + e.getValue()).collect(Collectors.joining("; "));
+                                    .limit(10).map(e -> NltkPorter.stem(e.getKey())  + " " + e.getValue()).limit(5).collect(Collectors.joining("; "));
         String parentLinks = conn.parents(doc.id()).stream()
                                                     .map(x -> x.url().toString())
                                                     .map(x -> "<div class=\"searchResultPageLink\"><a href=\"%s\">%s</a></div>".formatted(x,x))

--- a/src/main/java/hk/ust/comp4321/spider/Spider.java
+++ b/src/main/java/hk/ust/comp4321/spider/Spider.java
@@ -159,8 +159,8 @@ public class Spider {
 
         DatabaseConnection conn = new DatabaseConnection(phaseOneDb);
         Spider spider = new Spider(URI.create("https://www.cse.ust.hk/~kwtleung/COMP4321/testpage.htm").toURL(), conn);
-        spider.discover(30);
-        writeToFile(phaseOneDb, phaseOneResult, 30); // This line is the one which reads from the database
+        spider.discover(300);
+        writeToFile(phaseOneDb, phaseOneResult, 300); // This line is the one which reads from the database
         conn.close();
     }
 

--- a/src/main/java/hk/ust/comp4321/util/DocumentLoadTask.java
+++ b/src/main/java/hk/ust/comp4321/util/DocumentLoadTask.java
@@ -1,0 +1,34 @@
+package hk.ust.comp4321.util;
+
+import hk.ust.comp4321.api.Document;
+
+import java.util.List;
+import java.util.concurrent.RecursiveAction;
+import java.util.function.Consumer;
+
+public class DocumentLoadTask extends RecursiveAction {
+    private static final int THRESHOLD = 40;
+    private final List<Document> docs;
+    private final Consumer<Document> cons;
+
+    public DocumentLoadTask(List<Document> docs, Consumer<Document> cons) {
+        this.docs = docs;
+        this.cons = cons;
+    }
+
+    @Override
+    protected void compute() {
+        int size = docs.size();
+        if (size <= THRESHOLD) {
+            docs.forEach(cons);
+        } else {
+            int midpoint = size / 2;
+            DocumentLoadTask task1 = new DocumentLoadTask(docs.subList(0, midpoint), cons);
+            DocumentLoadTask task2 = new DocumentLoadTask(docs.subList(midpoint + 1, size), cons);
+            task1.fork();
+            task2.fork();
+            task1.join();
+            task2.join();
+        }
+    }
+}

--- a/src/main/java/hk/ust/comp4321/util/StopWord.java
+++ b/src/main/java/hk/ust/comp4321/util/StopWord.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,6 +32,26 @@ public class StopWord {
      */
     public static boolean isStopWord(String str) {
         return stopWords.contains(str);
+    }
+
+    /**
+     * Removes all stop words from a specified string.
+     * @param words The string to strip the stop words from
+     * @return The original string with all stopwords removed
+     */
+    public static String stripStopwords(String words) {
+        List<String> tokenized = new ArrayList<>(List.of(words.split(" ")));
+        StringBuilder sb = new StringBuilder(" ");
+        for (int i = 0; i < tokenized.size(); i++) {
+            String stripped = tokenized.get(i).replace("\"", "");
+            if (stopWords.contains(stripped)) {
+                sb.append(tokenized.get(i).contains("\"") ? "\"" : "");
+            } else {
+                sb.append(" ").append(tokenized.get(i));
+            }
+        }
+        System.out.println(sb.toString().replace(" \" ", " \"").strip());
+        return sb.toString().replace(" \" ", " \"").strip();
     }
 
     private StopWord() {}

--- a/src/main/java/hk/ust/comp4321/util/StopWord.java
+++ b/src/main/java/hk/ust/comp4321/util/StopWord.java
@@ -50,7 +50,6 @@ public class StopWord {
                 sb.append(" ").append(tokenized.get(i));
             }
         }
-        System.out.println(sb.toString().replace(" \" ", " \"").strip());
         return sb.toString().replace(" \" ", " \"").strip();
     }
 

--- a/src/test/java/hk/ust/comp4321/api/DocumentTest.java
+++ b/src/test/java/hk/ust/comp4321/api/DocumentTest.java
@@ -179,17 +179,33 @@ public class DocumentTest {
 
     @Test
     void asBodyVector() throws SQLException {
-        Document doc = conn.getDocFromId(1);
+        Document doc = conn.getDocFromId(0);
         doc.retrieveFromDatabase(conn);
-        assertTrue(doc.asBodyVector(conn.getDocuments()).cosineSim(new SearchVector("comput")) > 0);
-        assertEquals(0, doc.asBodyVector(conn.getDocuments()).cosineSim(new SearchVector("locat")));
+        List<Document> docs = conn.getDocuments();
+        docs.forEach(d -> {
+            try {
+                d.retrieveFromDatabase(conn);
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertTrue(doc.asBodyVector(docs).cosineSim(new SearchVector("comput")) > 0);
+        assertEquals(0, doc.asBodyVector(docs).cosineSim(new SearchVector("locat")));
     }
 
     @Test
     void asTitleVector() throws SQLException {
         Document doc = conn.getDocFromId(0);
         doc.retrieveFromDatabase(conn);
-        assertEquals(0, doc.asTitleVector(conn.getDocuments()).cosineSim(new SearchVector("locat")));
-        assertTrue(doc.asTitleVector(conn.getDocuments()).cosineSim(new SearchVector("comput")) > 0);
+        List<Document> docs = conn.getDocuments();
+        docs.forEach(d -> {
+            try {
+                d.retrieveFromDatabase(conn);
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertEquals(0, doc.asTitleVector(docs).cosineSim(new SearchVector("locat")));
+        assertTrue(doc.asTitleVector(docs).cosineSim(new SearchVector("comput")) > 0);
     }
 }

--- a/src/test/java/hk/ust/comp4321/api/DocumentTest.java
+++ b/src/test/java/hk/ust/comp4321/api/DocumentTest.java
@@ -181,15 +181,15 @@ public class DocumentTest {
     void asBodyVector() throws SQLException {
         Document doc = conn.getDocFromId(1);
         doc.retrieveFromDatabase(conn);
-        assertTrue(doc.asBodyVector(conn).cosineSim(new SearchVector("comput")) > 0);
-        assertEquals(0, doc.asBodyVector(conn).cosineSim(new SearchVector("locat")));
+        assertTrue(doc.asBodyVector(conn.getDocuments()).cosineSim(new SearchVector("comput")) > 0);
+        assertEquals(0, doc.asBodyVector(conn.getDocuments()).cosineSim(new SearchVector("locat")));
     }
 
     @Test
     void asTitleVector() throws SQLException {
         Document doc = conn.getDocFromId(0);
         doc.retrieveFromDatabase(conn);
-        assertEquals(0, doc.asTitleVector(conn).cosineSim(new SearchVector("locat")));
-        assertTrue(doc.asTitleVector(conn).cosineSim(new SearchVector("comput")) > 0);
+        assertEquals(0, doc.asTitleVector(conn.getDocuments()).cosineSim(new SearchVector("locat")));
+        assertTrue(doc.asTitleVector(conn.getDocuments()).cosineSim(new SearchVector("comput")) > 0);
     }
 }

--- a/src/test/java/hk/ust/comp4321/db/TableOperationTest.java
+++ b/src/test/java/hk/ust/comp4321/db/TableOperationTest.java
@@ -143,12 +143,12 @@ class TableOperationTest {
     void docFreq() {
         assertEquals(2, body.docFreq("comput"));
         assertEquals(0, body.docFreq("deconstruction"));
-        assertEquals(1, title.docFreq("comput"));
+        assertEquals(2, title.docFreq("comput"));
     }
 
     @Test
     void getDocIdsWithStem() {
         assertEquals(2, body.getDocIdsWithStem(0).size());
-        assertEquals(1, title.getDocIdsWithStem(0).size());
+        assertEquals(2, title.getDocIdsWithStem(0).size());
     }
 }

--- a/src/test/java/hk/ust/comp4321/se/SearchVectorTest.java
+++ b/src/test/java/hk/ust/comp4321/se/SearchVectorTest.java
@@ -10,14 +10,14 @@ class SearchVectorTest {
 
     @Test
     void cosineSim() {
-        SearchVector doc = new SearchVector(List.of("rage", "against", "dying", "light"), List.of(0.2, 0.1, 0.1, 0.1));
+        SearchVector doc = new SearchVector(List.of("rage", "dying", "light"), List.of(0.2, 0.1, 0.1));
         assertEquals(0, doc.cosineSim(new SearchVector("alpha-beta pruning is a technique")));
         assertNotEquals(0, doc.cosineSim(new SearchVector("dying light")));
         assertNotEquals(0, doc.cosineSim(new SearchVector("dying of the light")));
         assertEquals(doc.cosineSim(new SearchVector("dying light eye universe")),
-                doc.cosineSim(new SearchVector("dying of the light")));
+                doc.cosineSim(new SearchVector("gentle night dying of the light")));
         assertTrue(doc.cosineSim(new SearchVector("dying light")) >
-                doc.cosineSim(new SearchVector("dying of the light")));
+                doc.cosineSim(new SearchVector("burn rave dying of the light")));
         assertTrue(doc.cosineSim(new SearchVector("dying light")) >
                 doc.cosineSim(new SearchVector("dying")));
     }


### PR DESCRIPTION
Calculates document frequencies with pre-loaded documents instead of dynamically recalculating them.

Also fixes #29 by dealing with the stopwords.